### PR TITLE
Fix release workflow validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ permissions:
   contents: read
 
 jobs:
+  workflow-lint:
+    name: Validate workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.25.14"
+      - name: Install pinned actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca
+      - name: Validate GitHub Actions workflows
+        run: |
+          "$(go env GOPATH)/bin/actionlint" .github/workflows/*.yml
+
   test:
     name: Test (${{ matrix.os }}, Python ${{ matrix.python }})
     strategy:
@@ -37,10 +52,13 @@ jobs:
   required:
     name: CI / Required
     if: always()
-    needs: [test]
+    needs: [test, workflow-lint]
     runs-on: ubuntu-latest
     steps:
-      - name: Require every matrix job
+      - name: Require matrix and workflow validation
         env:
           MATRIX_RESULT: ${{ needs.test.result }}
-        run: test "$MATRIX_RESULT" = success
+          WORKFLOW_LINT_RESULT: ${{ needs.workflow-lint.result }}
+        run: |
+          test "$MATRIX_RESULT" = success
+          test "$WORKFLOW_LINT_RESULT" = success

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -18,9 +18,6 @@ jobs:
   draft:
     name: Verify and prepare draft
     runs-on: ubuntu-latest
-    env:
-      DIST_A: ${{ runner.temp }}/release-dist-a
-      DIST_B: ${{ runner.temp }}/release-dist-b
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.4.0
         with:
@@ -50,6 +47,8 @@ jobs:
       - name: Test and build twice
         env:
           TAG: ${{ inputs.tag }}
+          DIST_A: ${{ runner.temp }}/release-dist-a
+          DIST_B: ${{ runner.temp }}/release-dist-b
         run: |
           set -euo pipefail
           ./scripts/test
@@ -70,6 +69,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
           COMMIT: ${{ steps.release.outputs.commit }}
+          DIST_A: ${{ runner.temp }}/release-dist-a
         run: |
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -34,7 +34,7 @@ class GovernanceTests(unittest.TestCase):
             self.assertEqual(1, rejected.returncode)
             self.assertIn("duplicate JSON key", json.loads(rejected.stdout)["error"])
 
-    def test_every_workflow_action_is_immutably_pinned_and_yaml_parses(self) -> None:
+    def test_every_workflow_action_is_immutably_pinned(self) -> None:
         workflows = sorted(WORKFLOWS.glob("*.yml"))
         self.assertEqual({"ci.yml", "codeql.yml", "contract-drift.yml", "release-draft.yml"}, {path.name for path in workflows})
         for path in workflows:
@@ -54,8 +54,12 @@ class GovernanceTests(unittest.TestCase):
             self.assertIn(os_name, text)
         for version in ('"3.11"', '"3.12"', '"3.13"'):
             self.assertIn(version, text)
+        self.assertIn("name: Validate workflows", text)
+        self.assertIn("actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16", text)
+        self.assertIn("actionlint/cmd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca", text)
+        self.assertIn('actionlint" .github/workflows/*.yml', text)
         self.assertIn("name: CI / Required", text)
-        self.assertIn("needs: [test]", text)
+        self.assertIn("needs: [test, workflow-lint]", text)
 
     def test_release_automation_is_draft_only_and_rechecks_remote_identity(self) -> None:
         workflow = (WORKFLOWS / "release-draft.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- move runner temporary-directory expressions into step-level environments where the runner context is available
- validate every GitHub Actions workflow with actionlint pinned to an immutable upstream commit
- make the stable CI / Required gate depend on workflow validation and the full test matrix

## Verification

- actionlint .github/workflows/*.yml
- ./scripts/test (49 tests)
- git diff --check
- exact pinned actionlint install command builds v1.7.12 and validates the workflows

No tag, release, publication, or submission is performed by this PR.