### PR TITLE
Fix draft release recovery

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -73,17 +73,23 @@ jobs:
         run: |
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
-            test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .draft)" = true
+            test "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = true
           else
             gh release create "$TAG" --verify-tag --draft --title "$TAG" --notes-file submission/release-notes.md
           fi
           gh release upload "$TAG" "$DIST_A"/* --clobber
           download="$(mktemp -d)"
-          gh release download "$TAG" --dir "$download"
+          for attempt in 1 2 3 4 5; do
+            if gh release download "$TAG" --dir "$download" --clobber; then
+              break
+            fi
+            test "$attempt" -lt 5
+            sleep "$((attempt * 2))"
+          done
           diff -qr "$DIST_A" "$download"
           remote_main="$(git ls-remote origin refs/heads/main | cut -f1)"
           remote_tag="$(git ls-remote origin "refs/tags/$TAG" | cut -f1)"
           test "$COMMIT" = "$remote_main"
           test "$remote_tag" = "$(git rev-parse "refs/tags/$TAG")"
-          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG" --jq .draft)" = true
+          test "$(gh release view "$TAG" --json isDraft --jq .isDraft)" = true
           printf 'Draft verified. This workflow never publishes releases.\n'

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -72,6 +72,10 @@ class GovernanceTests(unittest.TestCase):
         self.assertIn('DIST_B: ${{ runner.temp }}/release-dist-b', workflow)
         self.assertIn('diff -qr "$DIST_A" "$DIST_B"', workflow)
         self.assertIn('diff -qr "$DIST_A" "$download"', workflow)
+        self.assertNotIn('releases/tags/$TAG', workflow)
+        self.assertEqual(2, workflow.count('gh release view "$TAG" --json isDraft --jq .isDraft'))
+        self.assertIn('for attempt in 1 2 3 4 5', workflow)
+        self.assertIn('gh release download "$TAG" --dir "$download" --clobber', workflow)
         self.assertIn("CI / Required", workflow)
 
         runbook = (REPO / "docs/RELEASING.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- inspect unpublished releases through gh release view instead of the REST tag endpoint that returns 404 for drafts
- retry draft asset download with a bounded backoff to tolerate first-creation indexing delay
- preserve draft-only behavior, exact tag/main binding, asset comparison, and final remote identity checks

## Failure evidence

Release draft run 33389509115 passed tag binding, required CI, tests, two byte-identical builds, provenance attestation, artifact upload, draft creation, and all eight asset uploads. It failed when the workflow queried the unpublished draft through repos/.../releases/tags/v0.2.2. Recovery attempt 2 reproduced the same 404 before asset upload.

## Verification

- actionlint .github/workflows/*.yml
- ./scripts/test (49 tests)
- git diff --check

The existing v0.2.2 release remains an unpublished draft with eight assets.