### PR TITLE
Generate Plugin Workbench projects by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+contracts/*.json text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Build Omarchy Plugins are documented here.
 
+## Unreleased
+
+- Generate the schema-one Plugin Workbench project definition by default.
+- Register `./tests/run` as an explicit, initially untrusted Workbench check.
+- Pin and verify the upstream Workbench authoring contract.
+- Document the separately versioned builder and local-lifecycle companion boundary.
+
 ## 0.2.3 — 2026-08-31
 
 - Validate every GitHub Actions workflow with pinned actionlint and include

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ upload, reviewer materials, strict source/release manifests, an SPDX 2.3 SBOM,
 and one checksum manifest. Artifacts are built from the exact committed Git
 tree rather than ambient working files.
 
+## Plugin Workbench companion
+
+[Plugin Workbench](https://github.com/tcballard/omarchy-plugin-workbench) is the
+default local lifecycle companion for projects created by this toolkit. New
+scaffolds include a schema-one `.omarchy-workbench.json` definition that points
+to the root plugin and proposes `./tests/run` as an exact-argv project check.
+
+Workbench can then register the checkout for validation, live linking,
+snapshots, rollback, and enable/disable operations. Registration does not trust
+or execute the generated check; the user must review the definition and approve
+project checks explicitly. The Workbench contract is vendored and pinned in
+[`contracts/upstream-contracts.json`](contracts/upstream-contracts.json).
+
 ## Scope
 
 The default target is an Omarchy 4 Quattro shell plugin: a public Git repository

--- a/contracts/upstream-contracts.json
+++ b/contracts/upstream-contracts.json
@@ -37,6 +37,19 @@
         "Quattro plugins use a root manifest.json and hosted QML entry points.",
         "Third-party plugin code executes inside the long-running shell process."
       ]
+    },
+    {
+      "name": "Omarchy Plugin Workbench project definition",
+      "repository": "https://github.com/tcballard/omarchy-plugin-workbench",
+      "trackedRef": "refs/heads/codex/builder-companion-contract",
+      "pinnedCommit": "3af9a969d88a0f328f948077c19fbbe4f825ca24",
+      "path": "contracts/project-definition.schema.json",
+      "sha256": "1e6d694c8881f042c7aa2d09b43d58c647c5def106392672227d4c1f05d90fd7",
+      "vendoredPath": "contracts/workbench-project-definition.schema.json",
+      "assumptions": [
+        "Generated root plugins declare pluginPath as '.'.",
+        "Project checks are exact argument vectors and remain untrusted until the owner approves them."
+      ]
     }
   ]
 }

--- a/contracts/workbench-project-definition.schema.json
+++ b/contracts/workbench-project-definition.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/tcballard/omarchy-plugin-workbench/blob/main/contracts/project-definition.schema.json",
+  "title": "Omarchy Plugin Workbench project definition",
+  "description": "The declarative, explicitly trusted integration contract for a local Omarchy plugin project.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "pluginPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?![A-Za-z]:)(?![/\\\\])(?!.*(?:^|[/\\\\])\\.\\.(?:[/\\\\]|$)).+$",
+      "description": "A relative path from the project root to manifest.json. Use '.' for a root plugin."
+    },
+    "checks": {
+      "type": "array",
+      "maxItems": 32,
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/check"
+      }
+    }
+  },
+  "$defs": {
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "argv"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 4096
+          },
+          "description": "An exact argument vector. Workbench never interprets it through a shell."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1800,
+          "default": 300
+        }
+      }
+    }
+  }
+}

--- a/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/SKILL.md
+++ b/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/SKILL.md
@@ -41,7 +41,18 @@ selecting optional flags or extending the output.
   contracts.
 
 After generation, run the generated `./tests/run` and the current toolkit
-validator from `omarchy-plugin-test`. On an Omarchy machine also run:
+validator from `omarchy-plugin-test`. Generated repositories include the
+schema-one `.omarchy-workbench.json` companion contract. If Plugin Workbench is
+installed, register the checkout, review the declared command, and make the
+trust decision explicitly:
+
+```bash
+omarchy-plugin-workbench add /absolute/path/to/plugin-name
+omarchy-plugin-workbench trust io.github.owner.plugin-name
+omarchy-plugin-workbench check io.github.owner.plugin-name
+```
+
+On an Omarchy machine also run:
 
 ```bash
 omarchy plugin validate /absolute/path/to/plugin-name

--- a/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/references/generated-layout.md
+++ b/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/references/generated-layout.md
@@ -5,6 +5,7 @@ The generator creates a standalone public Git repository with this baseline:
 ```text
 plugin-name/
 ├── .github/workflows/test.yml
+├── .omarchy-workbench.json
 ├── demo/fixtures/example.json
 ├── scripts/validate_manifest.py
 ├── tests/run
@@ -48,3 +49,8 @@ instructions, and license.
 The generated validator is a portable structural check for CI. On the target
 machine, `omarchy plugin validate .` remains authoritative for the installed
 Omarchy revision.
+
+The Workbench definition declares the root plugin and the exact
+`["./tests/run"]` argument vector. Plugin Workbench reads that command during
+registration but deliberately leaves it untrusted until the user reviews the
+file and explicitly approves project checks.

--- a/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
+++ b/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
@@ -154,6 +154,20 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
     return manifest
 
 
+def build_workbench_definition() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "pluginPath": ".",
+        "checks": [
+            {
+                "name": "project-tests",
+                "argv": ["./tests/run"],
+                "timeoutSeconds": 300,
+            }
+        ],
+    }
+
+
 def populate(root: Path, args: argparse.Namespace) -> None:
     repository = inferred_repository(args.plugin_id, args.output.name)
     namespace = re.sub(r"[^a-z0-9-]", "-", args.plugin_id.replace(".", "-"))
@@ -176,6 +190,11 @@ def populate(root: Path, args: argparse.Namespace) -> None:
         "KINDS": ", ".join(args.kind),
     }
     write_text(root, "manifest.json", json.dumps(build_manifest(args), indent=2, ensure_ascii=False) + "\n")
+    write_text(
+        root,
+        ".omarchy-workbench.json",
+        json.dumps(build_workbench_definition(), indent=2, ensure_ascii=False) + "\n",
+    )
     for kind in args.kind:
         _, filename = KINDS[kind]
         write_text(root, filename, render(filename + ".tpl", values))
@@ -232,7 +251,12 @@ def main(argv: list[str] | None = None) -> int:
         "id": args.plugin_id,
         "kinds": args.kind,
         "manifest": str(output / "manifest.json"),
-        "next": [str(output / "tests" / "run"), f"omarchy plugin validate {output}"],
+        "workbench": str(output / ".omarchy-workbench.json"),
+        "next": [
+            str(output / "tests" / "run"),
+            f"omarchy plugin validate {output}",
+            f"omarchy-plugin-workbench add {output}",
+        ],
     }, indent=2))
     return 0
 

--- a/scripts/check_contracts.py
+++ b/scripts/check_contracts.py
@@ -18,6 +18,7 @@ from typing import Any
 COMMIT = re.compile(r"^[0-9a-f]{40}$")
 DIGEST = re.compile(r"^[0-9a-f]{64}$")
 ENTRY_KEYS = {"name", "repository", "trackedRef", "pinnedCommit", "path", "sha256", "assumptions"}
+OPTIONAL_ENTRY_KEYS = {"vendoredPath"}
 
 
 def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -39,7 +40,11 @@ def load(path: Path) -> dict[str, Any]:
         raise ValueError("contract ledger must contain entries")
     names: set[str] = set()
     for entry in value["contracts"]:
-        if not isinstance(entry, dict) or set(entry) != ENTRY_KEYS:
+        if (
+            not isinstance(entry, dict)
+            or not ENTRY_KEYS.issubset(entry)
+            or not set(entry).issubset(ENTRY_KEYS | OPTIONAL_ENTRY_KEYS)
+        ):
             raise ValueError("contract entry has unexpected fields")
         if not isinstance(entry["name"], str) or not entry["name"] or entry["name"] in names:
             raise ValueError("contract names must be unique non-empty strings")
@@ -52,6 +57,12 @@ def load(path: Path) -> dict[str, Any]:
             raise ValueError(f"invalid immutable pin for {entry['name']}")
         if not isinstance(entry["path"], str) or entry["path"].startswith("/") or ".." in Path(entry["path"]).parts:
             raise ValueError(f"invalid contract path for {entry['name']}")
+        if "vendoredPath" in entry and (
+            not isinstance(entry["vendoredPath"], str)
+            or entry["vendoredPath"].startswith("/")
+            or ".." in Path(entry["vendoredPath"]).parts
+        ):
+            raise ValueError(f"invalid vendored contract path for {entry['name']}")
         if not isinstance(entry["assumptions"], list) or not entry["assumptions"] or not all(isinstance(item, str) and item for item in entry["assumptions"]):
             raise ValueError(f"missing assumptions for {entry['name']}")
     return value
@@ -95,7 +106,13 @@ def main(argv: list[str] | None = None) -> int:
         ledger = load(args.ledger)
         results = []
         for entry in ledger["contracts"]:
-            item = {"name": entry["name"], "pinValid": True, "contentVerified": False, "head": None, "drifted": False}
+            item = {"name": entry["name"], "pinValid": True, "contentVerified": False, "vendoredVerified": False, "head": None, "drifted": False}
+            if "vendoredPath" in entry:
+                vendored = args.ledger.resolve().parent.parent / entry["vendoredPath"]
+                actual = hashlib.sha256(vendored.read_bytes()).hexdigest()
+                if actual != entry["sha256"]:
+                    raise ValueError(f"vendored content digest mismatch for {entry['name']}")
+                item["vendoredVerified"] = True
             if args.online:
                 actual = hashlib.sha256(fetch(pinned_url(entry))).hexdigest()
                 if actual != entry["sha256"]:

--- a/skills/omarchy-plugin-scaffold/SKILL.md
+++ b/skills/omarchy-plugin-scaffold/SKILL.md
@@ -41,7 +41,18 @@ selecting optional flags or extending the output.
   contracts.
 
 After generation, run the generated `./tests/run` and the current toolkit
-validator from `omarchy-plugin-test`. On an Omarchy machine also run:
+validator from `omarchy-plugin-test`. Generated repositories include the
+schema-one `.omarchy-workbench.json` companion contract. If Plugin Workbench is
+installed, register the checkout, review the declared command, and make the
+trust decision explicitly:
+
+```bash
+omarchy-plugin-workbench add /absolute/path/to/plugin-name
+omarchy-plugin-workbench trust io.github.owner.plugin-name
+omarchy-plugin-workbench check io.github.owner.plugin-name
+```
+
+On an Omarchy machine also run:
 
 ```bash
 omarchy plugin validate /absolute/path/to/plugin-name

--- a/skills/omarchy-plugin-scaffold/references/generated-layout.md
+++ b/skills/omarchy-plugin-scaffold/references/generated-layout.md
@@ -5,6 +5,7 @@ The generator creates a standalone public Git repository with this baseline:
 ```text
 plugin-name/
 ├── .github/workflows/test.yml
+├── .omarchy-workbench.json
 ├── demo/fixtures/example.json
 ├── scripts/validate_manifest.py
 ├── tests/run
@@ -48,3 +49,8 @@ instructions, and license.
 The generated validator is a portable structural check for CI. On the target
 machine, `omarchy plugin validate .` remains authoritative for the installed
 Omarchy revision.
+
+The Workbench definition declares the root plugin and the exact
+`["./tests/run"]` argument vector. Plugin Workbench reads that command during
+registration but deliberately leaves it untrusted until the user reviews the
+file and explicitly approves project checks.

--- a/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
+++ b/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
@@ -154,6 +154,20 @@ def build_manifest(args: argparse.Namespace) -> dict[str, object]:
     return manifest
 
 
+def build_workbench_definition() -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "pluginPath": ".",
+        "checks": [
+            {
+                "name": "project-tests",
+                "argv": ["./tests/run"],
+                "timeoutSeconds": 300,
+            }
+        ],
+    }
+
+
 def populate(root: Path, args: argparse.Namespace) -> None:
     repository = inferred_repository(args.plugin_id, args.output.name)
     namespace = re.sub(r"[^a-z0-9-]", "-", args.plugin_id.replace(".", "-"))
@@ -176,6 +190,11 @@ def populate(root: Path, args: argparse.Namespace) -> None:
         "KINDS": ", ".join(args.kind),
     }
     write_text(root, "manifest.json", json.dumps(build_manifest(args), indent=2, ensure_ascii=False) + "\n")
+    write_text(
+        root,
+        ".omarchy-workbench.json",
+        json.dumps(build_workbench_definition(), indent=2, ensure_ascii=False) + "\n",
+    )
     for kind in args.kind:
         _, filename = KINDS[kind]
         write_text(root, filename, render(filename + ".tpl", values))
@@ -232,7 +251,12 @@ def main(argv: list[str] | None = None) -> int:
         "id": args.plugin_id,
         "kinds": args.kind,
         "manifest": str(output / "manifest.json"),
-        "next": [str(output / "tests" / "run"), f"omarchy plugin validate {output}"],
+        "workbench": str(output / ".omarchy-workbench.json"),
+        "next": [
+            str(output / "tests" / "run"),
+            f"omarchy plugin validate {output}",
+            f"omarchy-plugin-workbench add {output}",
+        ],
     }, indent=2))
     return 0
 

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -13,6 +13,10 @@ WORKFLOWS = REPO / ".github/workflows"
 
 
 class GovernanceTests(unittest.TestCase):
+    def test_pinned_contract_bytes_use_portable_line_endings(self) -> None:
+        attributes = (REPO / ".gitattributes").read_text(encoding="utf-8")
+        self.assertIn("contracts/*.json text eol=lf", attributes.splitlines())
+
     def test_contract_ledger_is_strict_and_offline_check_passes(self) -> None:
         result = subprocess.run(
             [sys.executable, str(REPO / "scripts/check_contracts.py"), "--json"],

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -21,7 +21,12 @@ class GovernanceTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         payload = json.loads(result.stdout)
         self.assertTrue(payload["ok"])
-        self.assertEqual(3, len(payload["contracts"]))
+        self.assertEqual(4, len(payload["contracts"]))
+        workbench = next(
+            item for item in payload["contracts"]
+            if item["name"] == "Omarchy Plugin Workbench project definition"
+        )
+        self.assertTrue(workbench["vendoredVerified"])
 
         ledger = (REPO / "contracts/upstream-contracts.json").read_text(encoding="utf-8")
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -202,6 +202,33 @@ class ToolTests(unittest.TestCase):
             self.assertEqual(0, validated.returncode, validated.stdout + validated.stderr)
             portable = run([str(output / "tests" / "run")], cwd=output)
             self.assertEqual(0, portable.returncode, portable.stdout + portable.stderr)
+            workbench = json.loads(
+                (output / ".omarchy-workbench.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                {
+                    "schemaVersion": 1,
+                    "pluginPath": ".",
+                    "checks": [
+                        {
+                            "name": "project-tests",
+                            "argv": ["./tests/run"],
+                            "timeoutSeconds": 300,
+                        }
+                    ],
+                },
+                workbench,
+            )
+            schema = json.loads(
+                (REPO / "contracts/workbench-project-definition.schema.json")
+                .read_text(encoding="utf-8")
+            )
+            self.assertEqual(1, schema["properties"]["schemaVersion"]["const"])
+            self.assertFalse(schema["additionalProperties"])
+            self.assertEqual(
+                1800,
+                schema["$defs"]["check"]["properties"]["timeoutSeconds"]["maximum"],
+            )
 
     def test_generator_refuses_nonempty_destination(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- generate `.omarchy-workbench.json` in every new plugin repository
- declare the root plugin and exact `./tests/run` argv with no automatic trust
- vendor and SHA-256-pin Workbench project-definition schema v1
- verify the vendored schema against the exact upstream Workbench commit
- keep the canonical and OpenAI adapter skill copies synchronized
- document the separately versioned authoring/lifecycle companion boundary

## Verification

- all 49 repository tests pass from a clean private checkout
- Linux, macOS, and Windows CI passes on Python 3.11, 3.12, and 3.13 at final head `1998a0d485facf4cca49b3401b34994cc6e592a1`
- stable `CI / Required` passes
- CodeQL passes
- exact pinned contract content verified online
- generated six-kind fixture passes strict validation and `./tests/run`
- deterministic package and release-preflight suites pass
- pinned JSON contract bytes are forced to LF on every platform

## Dependency

Depends on tcballard/omarchy-plugin-workbench#3. The current contract pin is Workbench PR commit `3af9a969d88a0f328f948077c19fbbe4f825ca24`. After that PR merges, update this ledger entry to the immutable merge commit and track `refs/heads/main` before marking this PR ready.