### PR TITLE
Generate agent-neutral Workbench workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Build Omarchy Plugins are documented here.
 
 ## Unreleased
 
+- Generate agent-neutral Workbench environment probes and a capability-gated validation workflow.
 - Generate the schema-one Plugin Workbench project definition by default.
 - Register `./tests/run` as an explicit, initially untrusted Workbench check.
 - Pin and verify the upstream Workbench authoring contract.

--- a/README.md
+++ b/README.md
@@ -160,12 +160,14 @@ tree rather than ambient working files.
 [Plugin Workbench](https://github.com/tcballard/omarchy-plugin-workbench) is the
 default local lifecycle companion for projects created by this toolkit. New
 scaffolds include a schema-one `.omarchy-workbench.json` definition that points
-to the root plugin and proposes `./tests/run` as an exact-argv project check.
+to the root plugin, proposes `./tests/run` as an exact-argv check and
+capability-gated validation workflow, and declares Git, Python, and optional
+Omarchy environment probes.
 
 Workbench can then register the checkout for validation, live linking,
 snapshots, rollback, and enable/disable operations. Registration does not trust
-or execute the generated check; the user must review the definition and approve
-project checks explicitly. The Workbench contract is vendored and pinned in
+or execute the generated commands; the user must review the definition and
+approve project commands and workflow capabilities explicitly. The Workbench contract is vendored and pinned in
 [`contracts/upstream-contracts.json`](contracts/upstream-contracts.json).
 
 ## Scope

--- a/contracts/upstream-contracts.json
+++ b/contracts/upstream-contracts.json
@@ -41,14 +41,15 @@
     {
       "name": "Omarchy Plugin Workbench project definition",
       "repository": "https://github.com/tcballard/omarchy-plugin-workbench",
-      "trackedRef": "refs/heads/codex/builder-companion-contract",
-      "pinnedCommit": "3af9a969d88a0f328f948077c19fbbe4f825ca24",
+      "trackedRef": "refs/heads/codex/agent-neutral-orchestration",
+      "pinnedCommit": "1192fc56517dc08162eee4c8592a9f52b2444cb4",
       "path": "contracts/project-definition.schema.json",
-      "sha256": "1e6d694c8881f042c7aa2d09b43d58c647c5def106392672227d4c1f05d90fd7",
+      "sha256": "c9b003c9810a653ac2da0febca9277d880c8f1a4369b7d3de94d824bdc830e00",
       "vendoredPath": "contracts/workbench-project-definition.schema.json",
       "assumptions": [
         "Generated root plugins declare pluginPath as '.'.",
-        "Project checks are exact argument vectors and remain untrusted until the owner approves them."
+        "Project commands are exact argument vectors and remain untrusted until the owner approves them.",
+        "Workflow capabilities require separate local approval and do not name an agent host."
       ]
     }
   ]

--- a/contracts/workbench-project-definition.schema.json
+++ b/contracts/workbench-project-definition.schema.json
@@ -25,6 +25,22 @@
       "items": {
         "$ref": "#/$defs/check"
       }
+    },
+    "workflows": {
+      "type": "array",
+      "maxItems": 32,
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/workflow"
+      }
+    },
+    "environment": {
+      "type": "array",
+      "maxItems": 32,
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/environment"
+      }
     }
   },
   "$defs": {
@@ -58,6 +74,48 @@
           "maximum": 1800,
           "default": 300
         }
+      }
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "capability", "argv"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 80},
+        "capability": {
+          "enum": ["validate", "preview", "package", "release-check", "network", "publish", "deploy", "write-outside-project"]
+        },
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {"type": "string", "minLength": 1, "maxLength": 4096}
+        },
+        "timeoutSeconds": {"type": "integer", "minimum": 1, "maximum": 1800, "default": 300},
+        "requires": {
+          "type": "array",
+          "maxItems": 8,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "enum": ["validate", "preview", "package", "release-check", "network", "publish", "deploy", "write-outside-project"]
+          }
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "argv"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 80},
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": {"type": "string", "minLength": 1, "maxLength": 4096}
+        },
+        "required": {"type": "boolean", "default": true}
       }
     }
   }

--- a/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/references/generated-layout.md
+++ b/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/references/generated-layout.md
@@ -51,6 +51,9 @@ machine, `omarchy plugin validate .` remains authoritative for the installed
 Omarchy revision.
 
 The Workbench definition declares the root plugin and the exact
-`["./tests/run"]` argument vector. Plugin Workbench reads that command during
-registration but deliberately leaves it untrusted until the user reviews the
-file and explicitly approves project checks.
+`["./tests/run"]` argument vector as both a portable check and a
+capability-gated validation workflow. It also declares Git and Python as
+required environment probes and Omarchy as optional. Plugin Workbench reads
+those commands during registration but deliberately leaves them untrusted until
+the user reviews the file and explicitly approves project commands and the
+workflow capability.

--- a/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
+++ b/plugins/build-omarchy-plugins/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
@@ -165,6 +165,20 @@ def build_workbench_definition() -> dict[str, object]:
                 "timeoutSeconds": 300,
             }
         ],
+        "environment": [
+            {"name": "git", "argv": ["git", "--version"], "required": True},
+            {"name": "python", "argv": ["python3", "--version"], "required": True},
+            {"name": "omarchy", "argv": ["omarchy", "--version"], "required": False},
+        ],
+        "workflows": [
+            {
+                "name": "portable-tests",
+                "capability": "validate",
+                "argv": ["./tests/run"],
+                "timeoutSeconds": 300,
+                "requires": [],
+            }
+        ],
     }
 
 

--- a/skills/omarchy-plugin-scaffold/references/generated-layout.md
+++ b/skills/omarchy-plugin-scaffold/references/generated-layout.md
@@ -51,6 +51,9 @@ machine, `omarchy plugin validate .` remains authoritative for the installed
 Omarchy revision.
 
 The Workbench definition declares the root plugin and the exact
-`["./tests/run"]` argument vector. Plugin Workbench reads that command during
-registration but deliberately leaves it untrusted until the user reviews the
-file and explicitly approves project checks.
+`["./tests/run"]` argument vector as both a portable check and a
+capability-gated validation workflow. It also declares Git and Python as
+required environment probes and Omarchy as optional. Plugin Workbench reads
+those commands during registration but deliberately leaves them untrusted until
+the user reviews the file and explicitly approves project commands and the
+workflow capability.

--- a/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
+++ b/skills/omarchy-plugin-scaffold/scripts/new_plugin.py
@@ -165,6 +165,20 @@ def build_workbench_definition() -> dict[str, object]:
                 "timeoutSeconds": 300,
             }
         ],
+        "environment": [
+            {"name": "git", "argv": ["git", "--version"], "required": True},
+            {"name": "python", "argv": ["python3", "--version"], "required": True},
+            {"name": "omarchy", "argv": ["omarchy", "--version"], "required": False},
+        ],
+        "workflows": [
+            {
+                "name": "portable-tests",
+                "capability": "validate",
+                "argv": ["./tests/run"],
+                "timeoutSeconds": 300,
+                "requires": [],
+            }
+        ],
     }
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -216,6 +216,20 @@ class ToolTests(unittest.TestCase):
                             "timeoutSeconds": 300,
                         }
                     ],
+                    "environment": [
+                        {"name": "git", "argv": ["git", "--version"], "required": True},
+                        {"name": "python", "argv": ["python3", "--version"], "required": True},
+                        {"name": "omarchy", "argv": ["omarchy", "--version"], "required": False},
+                    ],
+                    "workflows": [
+                        {
+                            "name": "portable-tests",
+                            "capability": "validate",
+                            "argv": ["./tests/run"],
+                            "timeoutSeconds": 300,
+                            "requires": [],
+                        }
+                    ],
                 },
                 workbench,
             )
@@ -229,6 +243,11 @@ class ToolTests(unittest.TestCase):
                 1800,
                 schema["$defs"]["check"]["properties"]["timeoutSeconds"]["maximum"],
             )
+            self.assertIn(
+                "preview",
+                schema["$defs"]["workflow"]["properties"]["capability"]["enum"],
+            )
+            self.assertEqual(32, schema["properties"]["environment"]["maxItems"])
 
     def test_generator_refuses_nonempty_destination(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- generate an agent-neutral validation workflow alongside the existing portable check
- declare Git and Python as required environment probes and Omarchy as optional
- vendor and byte-verify the expanded Workbench project schema
- keep the canonical Agent Plugin and OpenAI adapter in sync
- document that command trust and capability approval remain explicit and local

## Dependency

Depends on tcballard/omarchy-plugin-workbench#4.

The current contract pin is the exact Workbench PR commit `1192fc56517dc08162eee4c8592a9f52b2444cb4`. After Workbench #4 merges, update this PR to the immutable merge commit and `refs/heads/main`, re-run online verification, then mark it ready.

## Verification

- `scripts/test` — 50 tests passed plus plugin, adapter, version, contract, and security validation
- `python3 scripts/check_contracts.py --online --json` — all four exact pins verified; vendored Workbench bytes verified
- canonical and OpenAI scaffold adapters match
- generated workflow/environment assertions pass
