### PR TITLE
Finalize Workbench main contract pin

### DIFF
--- a/contracts/upstream-contracts.json
+++ b/contracts/upstream-contracts.json
@@ -41,8 +41,8 @@
     {
       "name": "Omarchy Plugin Workbench project definition",
       "repository": "https://github.com/tcballard/omarchy-plugin-workbench",
-      "trackedRef": "refs/heads/codex/agent-neutral-orchestration",
-      "pinnedCommit": "1192fc56517dc08162eee4c8592a9f52b2444cb4",
+      "trackedRef": "refs/heads/main",
+      "pinnedCommit": "48e211becaf7fa5df7676b1315ca26b0cab3fedc",
       "path": "contracts/project-definition.schema.json",
       "sha256": "c9b003c9810a653ac2da0febca9277d880c8f1a4369b7d3de94d824bdc830e00",
       "vendoredPath": "contracts/workbench-project-definition.schema.json",


### PR DESCRIPTION
## Summary

- track the Workbench project contract from `refs/heads/main`
- pin the immutable Workbench #4 merge commit `48e211becaf7fa5df7676b1315ca26b0cab3fedc`
- retain the already-verified schema digest and vendored bytes

## Verification

- `python3 scripts/check_contracts.py --online --json` — all four pins and Workbench vendored bytes verified
- governance plus generated-project contract tests — 7 passed
- diff is limited to the two intended ledger fields
